### PR TITLE
Patch 1

### DIFF
--- a/lib/fastlane/plugin/itargetchecker/actions/itargetchecker.rb
+++ b/lib/fastlane/plugin/itargetchecker/actions/itargetchecker.rb
@@ -11,11 +11,11 @@ class ITargetChecker
         # loop through all the project files
         project.files.each do |file|
 
-          faultyFile = file.name == nil || file.name == "" 
+          faultyFile = false
           if ignoredFiles
             ignoredFiles.each do |ignoredItem|
-                faultyFile = faultyFile || file.name.match(ignoredItem)
-                if faultyFile
+                faultyFile = file.path.match(ignoredItem)
+                if faultyFile               
                   next
                 end
             end
@@ -24,6 +24,7 @@ class ITargetChecker
           if faultyFile
             next
           end
+
 
           project.targets.each do |target|
 
@@ -41,7 +42,8 @@ class ITargetChecker
                 if correctTypes
                   # get all files of a target
                   buildPhase.files.each do |targetFile|
-                    if targetFile.display_name == file.name
+                  
+                    if targetFile.file_ref == file.uuid
                       found = true
                       break
                     end
@@ -50,7 +52,7 @@ class ITargetChecker
             end
 
             if found == false 
-              lostFiles.push("file: #{file.name} target: #{target}")
+              lostFiles.push("file: #{file.path} target: #{target}")
             end
           end
     end

--- a/lib/fastlane/plugin/itargetchecker/actions/itargetchecker.rb
+++ b/lib/fastlane/plugin/itargetchecker/actions/itargetchecker.rb
@@ -12,11 +12,13 @@ class ITargetChecker
         project.files.each do |file|
 
           faultyFile = false
+          fileName = file.path.split('/').last
+          
           if ignoredFiles
             ignoredFiles.each do |ignoredItem|
-                faultyFile = file.path.match(ignoredItem)
-                if faultyFile               
-                  next
+                faultyFile = fileName.match(ignoredItem)
+                if faultyFile
+                  break
                 end
             end
           end   
@@ -24,7 +26,6 @@ class ITargetChecker
           if faultyFile
             next
           end
-
 
           project.targets.each do |target|
 
@@ -43,7 +44,7 @@ class ITargetChecker
                   # get all files of a target
                   buildPhase.files.each do |targetFile|
                   
-                    if targetFile.file_ref == file.uuid
+                    if targetFile.file_ref.uuid == file.uuid
                       found = true
                       break
                     end
@@ -52,7 +53,7 @@ class ITargetChecker
             end
 
             if found == false 
-              lostFiles.push("file: #{file.path} target: #{target}")
+              lostFiles.push("file: #{fileName} target: #{target} ")
             end
           end
     end


### PR DESCRIPTION
The "file.name" is not a property that exists all the time. Replaced it with its path and extract the file name from it.
Breaks the loop from "ignoredFiles" when find first match.
 Changed the file name comparison with file UUID because it is more accurate.